### PR TITLE
upgrade to v2.3 not v2.4, and downgrade v2.4 to v2.3

### DIFF
--- a/app/src/main/java/com/kanedias/vanilla/audiotag/PluginTagWrapper.java
+++ b/app/src/main/java/com/kanedias/vanilla/audiotag/PluginTagWrapper.java
@@ -168,11 +168,11 @@ public class PluginTagWrapper {
     }
 
     /**
-     * upgrades ID3v2.x tag to ID3v2.4 for loaded file.
+     * upgrades ID3v2.x tag to ID3v2.3 for loaded file.
      * Call this method only if you know exactly that file contains ID3 tag.
      */
     public void upgradeID3v2() {
-        mTag = mAudioFile.convertID3Tag((AbstractID3v2Tag) mTag, ID3V2Version.ID3_V24);
+        mTag = mAudioFile.convertID3Tag((AbstractID3v2Tag) mTag, ID3V2Version.ID3_V23);
         mAudioFile.setTag(mTag);
         writeFile();
     }

--- a/app/src/main/java/com/kanedias/vanilla/audiotag/TagEditActivity.java
+++ b/app/src/main/java/com/kanedias/vanilla/audiotag/TagEditActivity.java
@@ -203,6 +203,7 @@ public class TagEditActivity extends DialogActivity {
         mWrapper.loadFile(true);
         fillInitialValues();
         miscellaneousChecks();
+        miscellaneousChecks2();
     }
 
     /**
@@ -253,7 +254,19 @@ public class TagEditActivity extends DialogActivity {
         if (mWrapper.getTag() instanceof ID3v22Tag) {
             new AlertDialog.Builder(this)
                     .setTitle(R.string.re_tag)
-                    .setMessage(R.string.id3_v22_to_v24)
+                    .setMessage(R.string.id3_v22_to_v23)
+                    .setPositiveButton(android.R.string.ok, (dialog, which) -> mWrapper.upgradeID3v2())
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show();
+        }
+    }
+
+    private void miscellaneousChecks2() {
+        // check we need a re-tag
+        if (mWrapper.getTag() instanceof ID3v24Tag) {
+            new AlertDialog.Builder(this)
+                    .setTitle(R.string.re_tag)
+                    .setMessage(R.string.id3_v24_to_v23)
                     .setPositiveButton(android.R.string.ok, (dialog, which) -> mWrapper.upgradeID3v2())
                     .setNegativeButton(android.R.string.cancel, null)
                     .show();


### PR DESCRIPTION
this is **COMPLETELY UNTESTED CODE** because i could not get it to build due to dependency problems.

i'm making a lot of assumptions about how things work, like swapping version numbers. my most curious question is.. can i use the "upgrade" function to *downgrade*? also, i just threw in a whole new `miscellaneousChecks2()` function, and i'm assuming i can just do that.

i think making everything downgrade to v2.3 is a good idea. if the user has v2.4 tags and they're working, then they probably won't run this app and so they can keep their v2.4 tags. but if someone needs to *fix* their tags, then we can assume that they really want to make *sure* their tags will work, so changing all v2.4 tags to v2.3 seems like the right thing to do.

